### PR TITLE
Fix version of elementary dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     install_requires=[
         'click>=7.0,<9',
         'dbt-core>=0.20,<2.0.0',
-        'elementary-data'
+        'elementary-data<0.4.2'
     ],
     extras_require={
         'snowflake': ['dbt-snowflake>=0.20,<2.0.0'],


### PR DESCRIPTION
`elementary-data:0.4.2` contains changes that break `jaffle-shop-goes-online`.

Fixes the behavior below:
```bash
pip install .
python cli.py --help
```

**Expected**: Help documentation displays
**Actual**: 
```
$ python cli.py --help
Traceback (most recent call last):
  File "jaffle-shop-goes-online\cli.py", line 2, in <module>
    from data_creation.initial_demo import initial_demo, initial_incremental_demo
  File "jaffle-shop-goes-online\data_creation\initial_demo.py", line 4, in <module>   
    from monitor.dbt_runner import DbtRunner
ModuleNotFoundError: No module named 'monitor.dbt_runner'
```