### PR TITLE
Renew cpa and roas

### DIFF
--- a/jaffle_shop_online/models/marketing/cpa_and_roas.sql
+++ b/jaffle_shop_online/models/marketing/cpa_and_roas.sql
@@ -1,10 +1,10 @@
 {{
     config(
-        materialized = "table",
+        materialized = "table"
     )
 }}
 
-with ad_spend as (
+with ad_spend_raw as (
 
     select * from {{ ref('ads_spend') }}
 
@@ -16,47 +16,66 @@ attribution as (
 
 ),
 
--- aggregate first as this is easier to debug / often leads to fewer fanouts
-ad_spend_aggregated as (
+-- Step 1: Aggregate spend per (month, source)
+ad_spend_monthly as (
 
     select
         date_trunc('month', date_day) as date_month,
         utm_source,
-
         sum(spend) as total_spend
-
-    from ad_spend
-
+    from ad_spend_raw
     group by 1, 2
 
 ),
 
+-- Step 2: Assign rank to months
+ad_spend_ranked as (
+
+    select *,
+        dense_rank() over (order by date_month desc) as month_rank
+    from ad_spend_monthly
+
+),
+
+-- Step 3: We filter rows where month_rank > 1 so we can exclude the current month
+ad_spend_filtered as (
+
+    select date_month, utm_source, total_spend
+    from ad_spend_ranked
+    where month_rank > 1
+
+),
+
+-- Step 4: Aggregate attribution per (month, source)
 attribution_aggregated as (
 
     select
         date_trunc('month', converted_at) as date_month,
         utm_source,
-
         sum(linear_points) as attribution_points,
         sum(linear_revenue) as attribution_revenue
-
     from attribution
-
     group by 1, 2
 
 ),
 
+-- Step 5: Join attribution with filtered spend
 joined as (
 
     select
-        *,
-        1.0 * nullif(total_spend, 0) / attribution_points as cost_per_acquisition,
-        1.0 * attribution_revenue / nullif(total_spend, 0) as return_on_advertising_spend
+        a.date_month,
+        a.utm_source,
+        a.attribution_points,
+        a.attribution_revenue,
+        s.total_spend,
 
-    from attribution_aggregated
+        1.0 * nullif(s.total_spend, 0) / a.attribution_points as cost_per_acquisition,
+        1.0 * a.attribution_revenue / nullif(s.total_spend, 0) as return_on_advertising_spend
 
-    full outer join ad_spend_aggregated
-    using (date_month, utm_source)
+    from attribution_aggregated a
+    left join ad_spend_filtered s
+      on a.date_month = s.date_month
+     and a.utm_source = s.utm_source
 
 )
 

--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -143,6 +143,22 @@ models:
       - name: total_spend
         data_type: number
         description: "Total spend amount (USD)"
+        data_tests:
+          - elementary.column_anomalies:
+              anomaly_direction: both
+              anomaly_sensitivity: 3
+              column_anomalies:
+              - null_count
+              detection_period:
+                count: 2
+                period: month
+              time_bucket:
+                count: 1
+                period: day
+              timestamp_column: date_month
+              training_period:
+                count: 12
+                period: month
 
       - name: cost_per_acquisition
         data_type: number

--- a/jaffle_shop_online/models/marketing/schema.yml
+++ b/jaffle_shop_online/models/marketing/schema.yml
@@ -152,9 +152,6 @@ models:
               detection_period:
                 count: 2
                 period: month
-              time_bucket:
-                count: 1
-                period: day
               timestamp_column: date_month
               training_period:
                 count: 12


### PR DESCRIPTION
### Purpose

This PR updates the `cpa_and_roas` model to **exclude the current (incomplete) month from cost and ROAS calculations**, improving the reliability of monthly performance metrics.

### Changes Made

* **Renamed CTEs** for clarity (`ad_spend` → `ad_spend_raw`, etc.)
* **Added ranking logic** to identify and filter out the latest month in ad spend data:

  * Uses `dense_rank()` over `date_month` to identify the most recent month.
  * Filters out the top-ranked month to avoid partial spend inflating metrics.
* **Changed join logic**:

  * Replaced `full outer join` with a **`left join`** from attribution to ad spend — prioritizing attribution visibility even when no spend data exists.
* **Maintained metrics**:

  * `cost_per_acquisition` and `return_on_advertising_spend` are still calculated, but now only for **complete months**.

### Why This Matters

* Reduces misleading spikes in **CPA/ROAS** from partially logged ad spend in the current month.
* Ensures **cleaner dashboards** and more trustworthy month-over-month comparisons.
* Improves **debuggability and maintainability** by restructuring logic into clearer, well-named steps.

### Notes

* Attribution data is still shown for the current month if available, but **ROAS and CPA will only compute where full spend exists**.
* This approach assumes that attribution data may be backfilled or complete even if spend isn’t yet finalized.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved clarity and structure of marketing spend calculations by reorganizing query steps and making data transformations more explicit.
  - Enhanced readability and maintainability of schema files through formatting updates and clearer tagging.

- **Tests**
  - Added anomaly detection for the total spend column to monitor data quality and identify unusual patterns.

- **Style**
  - Reformatted descriptions and lists in schema files for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->