### PR TITLE
chore: remove column anomaly tests from order amount field

### DIFF
--- a/jaffle_shop_online/models/schema.yml
+++ b/jaffle_shop_online/models/schema.yml
@@ -106,14 +106,6 @@ models:
 
       - name: amount
         description: Total amount (AUD) of the order
-        tests:
-          - elementary.column_anomalies:
-              config:
-                severity: warn
-                owner: ["@data-ops"]
-              column_anomalies:
-                - zero_count
-                - zero_percent
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card


### PR DESCRIPTION
* Eliminated the column anomaly tests for the 'amount' field in the order model to simplify the schema and reduce unnecessary checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an anomaly detection test from the "amount" column in the orders data model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->